### PR TITLE
Bring hooks in line with each other & non-major renovate

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = theses
+skip = *.bib,.github/styles

--- a/precommit/latex/latex-hooks.yml
+++ b/precommit/latex/latex-hooks.yml
@@ -1,10 +1,4 @@
 repos:
-  - repo: https://github.com/cmhughes/latexindent.pl
-    rev: V3.19
-    hooks:
-      - id: latexindent
-        args:
-          - -s
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -21,7 +15,21 @@ repos:
     hooks:
       - id: forbid-tabs
         exclude: ".dic$"
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.0
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
     hooks:
       - id: prettier
+  - repo: https://github.com/cmhughes/latexindent.pl
+    rev: V3.19
+    hooks:
+      - id: latexindent
+        args:
+          - -s

--- a/precommit/python/python-hooks.yml
+++ b/precommit/python/python-hooks.yml
@@ -1,13 +1,45 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: forbid-tabs
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.0
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3
     hooks:
       - id: ruff
       - id: ruff-format
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.16.0"
     hooks:
-      - id: forbid-tabs
+      - id: blacken-docs
+        additional_dependencies:
+          - black
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1
     hooks:
@@ -21,34 +53,3 @@ repos:
           # without which these dependencies would not be installed
           - numpy
           - pydantic
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
-    hooks:
-      - id: prettier
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
-      - id: check-case-conflict
-      - id: check-docstring-first
-      - id: check-merge-conflict
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args:
-          - --fix=lf
-      - id: trailing-whitespace
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.16.0"
-    hooks:
-      - id: blacken-docs
-        additional_dependencies:
-          - black
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
-    hooks:
-      - id: codespell
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.0
-    hooks:
-      - id: check-github-workflows

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -22,9 +22,10 @@
       "matchManagers": ["github-actions", "pre-commit"]
     },
     {
-      "description": "Only update once a month",
+      "description": "Only allow major standard upgrades",
+      "enabled": false,
       "matchDepNames": ["renovatebot/pre-commit-hooks"],
-      "schedule": ["on the first day of the month"]
+      "matchUpdateTypes": ["minor", "patch", "pin"]
     }
   ]
 }

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -22,7 +22,7 @@
       "matchManagers": ["github-actions", "pre-commit"]
     },
     {
-      "description": "Only allow major standard upgrades",
+      "description": "Only allow major updates",
       "enabled": false,
       "matchDepNames": ["renovatebot/pre-commit-hooks"],
       "matchUpdateTypes": ["minor", "patch", "pin"]


### PR DESCRIPTION
Adding `codespell` to `latex` and making the order consistent.

Disable non-major updates for `renovate`.