### PR TITLE
Remove `coveralls`

### DIFF
--- a/actions/python/tox/README.md
+++ b/actions/python/tox/README.md
@@ -26,30 +26,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
 ```
 
-where `x` is the `major` version of the action. If coverage with
-Coveralls is not desired, then modify the above to:
-
-```yaml
-jobs:
-  test:
-    name: ${{ matrix.os }} py${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        python-version:
-          - "3.x"
-    steps:
-      - uses: paddyroddy/.github/actions/python/tox@vx
-        with:
-          cache-path: |-
-            .tox
-          coverage-with-coveralls: no
-          operating-system: ${{ matrix.os }}
-          pyproject-toml: ./pyproject.toml
-          python-version: ${{ matrix.python-version }}
-```
+where `x` is the `major` version of the action.

--- a/actions/python/tox/action.yml
+++ b/actions/python/tox/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: Paths to cache
     required: true
 
-  coverage-with-coveralls:
-    description: Whether to produce coverage with Coveralls
-    default: yes
-
   operating-system:
     description: Operating system to test
     required: true
@@ -50,7 +46,3 @@ runs:
       run: tox run
       env:
         OS: ${{ inputs.operating-system }}
-
-    - name: Coverage
-      uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2
-      if: inputs.coverage-with-coveralls == 'yes'


### PR DESCRIPTION
Doesn't work for parallel builds as-is