### PR TITLE
Remove British spelling from `typos-cli`

### DIFF
--- a/precommit/general/general-hooks.yaml
+++ b/precommit/general/general-hooks.yaml
@@ -54,7 +54,6 @@ repos:
         args:
           - --force-exclude
           - --hidden
-          - --locale=en-gb
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:


### PR DESCRIPTION
Creating more noise than its worth, unfortunately.