### PR TITLE
Switch from `tox-gh-actions` to `tox-gh`

### DIFF
--- a/actions/python/tox/README.md
+++ b/actions/python/tox/README.md
@@ -20,7 +20,6 @@ jobs:
       - uses: paddyroddy/.github/actions/python/tox@vx
         with:
           cache-path: .tox
-          operating-system: ${{ matrix.os }}
           pyproject-toml: ./pyproject.toml
           python-version: ${{ matrix.python-version }}
 ```

--- a/actions/python/tox/action.yml
+++ b/actions/python/tox/action.yml
@@ -7,10 +7,6 @@ inputs:
     description: Paths to cache
     required: true
 
-  operating-system:
-    description: Operating system to test
-    required: true
-
   pyproject-toml:
     description: Path of pyproject.toml
     required: true
@@ -41,10 +37,10 @@ runs:
     - name: Install dependencies
       shell: bash
       run: >-
-        python -m pip install tox tox-gh-actions
+        python -m pip install tox tox-gh
 
     - name: Test with tox
       shell: bash
       run: tox run
       env:
-        OS: ${{ inputs.operating-system }}
+        TOX_GH_MAJOR_MINOR: ${{ inputs.python-version }}


### PR DESCRIPTION
Seeing as part of the `tox-dev` organisation, probably for the best