### PR TITLE
Remove `blacken-docs` and use `ruff-format`

### DIFF
--- a/prek/python/python-hooks.yaml
+++ b/prek/python/python-hooks.yaml
@@ -1,16 +1,15 @@
 ---
 repos:
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.20.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies:
-          - black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-check
       - id: ruff-format
+        types_or:
+          - jupyter
+          - markdown
+          - pyi
+          - python
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.20.2
     hooks:


### PR DESCRIPTION
Following the release of https://github.com/astral-sh/ruff/pull/23434 we can now format code using `ruff` and no longer need `blacken-docs`